### PR TITLE
Idsvr uriprovider

### DIFF
--- a/src/HealthChecks.IdSvr/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
+++ b/src/HealthChecks.IdSvr/DependencyInjection/IdSvrHealthCheckBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using HealthChecks.IdSvr;
+using HealthChecks.IdSvr;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System;
 using System.Collections.Generic;
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </param>
         /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
         /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
-        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns></param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
         public static IHealthChecksBuilder AddIdentityServer(this IHealthChecksBuilder builder, Uri idSvrUri, string name = default, HealthStatus? failureStatus = default, IEnumerable<string> tags = default,TimeSpan? timeout = default)
         {
             var registrationName = name ?? NAME;
@@ -34,6 +34,46 @@ namespace Microsoft.Extensions.DependencyInjection
                 failureStatus,
                 tags,
                 timeout));
+        }
+        /// <summary>
+        /// Add a health check for Identity Server.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+        /// <param name="uriProvider">Factory for providing the uri of the Identity Server to check.</param>
+        /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'idsvr' will be used for the name.</param>
+        /// <param name="failureStatus"></param>
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+        /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+        /// <param name="timeout">An optional System.TimeSpan representing the timeout of the check.</param>
+        /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        public static IHealthChecksBuilder AddIdentityServer(
+            this IHealthChecksBuilder builder,
+            Func<IServiceProvider, Uri> uriProvider,
+            string name = null,
+            HealthStatus? failureStatus = null,
+            IEnumerable<string> tags = null,
+            TimeSpan? timeout = null)
+        {
+            builder.Services.AddHttpClient();
+            var registrationName = name ?? NAME;
+
+            return builder.Add(
+                new HealthCheckRegistration(
+                    registrationName,
+                    sp => new IdSvrHealthCheck(() => CreateIdentityServerHttpClient(sp, registrationName, uriProvider)),
+                    failureStatus,
+                    tags,
+                    timeout));
+        }
+        private static HttpClient CreateIdentityServerHttpClient(IServiceProvider sp, string registrationName, Func<IServiceProvider, Uri> uriProvider)
+        {
+            var authorityUri = uriProvider(sp);
+            var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+            var client = httpClientFactory.CreateClient(registrationName);
+            client.BaseAddress = authorityUri;
+
+            return client;
         }
     }
 }

--- a/test/UnitTests/DependencyInjection/IdSrv/IdSrvUnitTests.cs
+++ b/test/UnitTests/DependencyInjection/IdSrv/IdSrvUnitTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using HealthChecks.IdSvr;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -33,6 +33,38 @@ namespace UnitTests.HealthChecks.DependencyInjection.IdSvr
             var services = new ServiceCollection();
             services.AddHealthChecks()
                 .AddIdentityServer(new Uri("http://myidsvr"), name: "my-idsvr-group");
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("my-idsvr-group");
+            check.GetType().Should().Be(typeof(IdSvrHealthCheck));
+        }
+        [Fact]
+        public void add_health_check_when_properly_configured_with_uri_provider()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddIdentityServer(sp => new Uri("http://myidsvr"));
+
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+            var registration = options.Value.Registrations.First();
+            var check = registration.Factory(serviceProvider);
+
+            registration.Name.Should().Be("idsvr");
+            check.GetType().Should().Be(typeof(IdSvrHealthCheck));
+        }
+        [Fact]
+        public void add_named_health_check_when_properly_configured_with_uri_provider()
+        {
+            var services = new ServiceCollection();
+            services.AddHealthChecks()
+                .AddIdentityServer(sp => new Uri("http://myidsvr"), name: "my-idsvr-group");
 
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<IOptions<HealthCheckServiceOptions>>();


### PR DESCRIPTION
**What this PR does / why we need it**:
Add overload to IdSvrHealthCheck which enables the uri to be resolved from the IServiceProvider.

**Does this PR introduce a user-facing change?**:
No

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ x] Code compiles correctly
- [ x] Created/updated tests
- [ x] Unit tests passing
- [ x] End-to-end tests passing
- [ -] Extended the documentation
- [ -] Provided sample for the feature
